### PR TITLE
fix: correct weekday display

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -159,7 +159,7 @@ func (s *Stats) Print() {
 
 	s.pChart("Weekly commits distribution (by day).",
 		vFormat,
-		[]string{"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"},
+		[]string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"},
 		s.ByDay)
 
 	fmt.Println()


### PR DESCRIPTION
[Weekday](https://golang.org/pkg/time/#Weekday) iota starts on Sunday.
This fixes the display of `Weekly commits distribution by day`.